### PR TITLE
Install and enable redis cache plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "he": "^1.1.0",
     "lodash": "^4.14.1",
     "phridge": "^2.0.0",
+    "prerender-redis-cache": "^0.1.6",
     "signal-exit": "^3.0.0"
   },
   "devDependencies": {

--- a/server.js
+++ b/server.js
@@ -16,5 +16,6 @@ server.use(prerender.removeScriptTags());
 server.use(prerender.httpHeaders());
 // server.use(prerender.inMemoryHtmlCache());
 // server.use(prerender.s3HtmlCache());
+server.use(require('prerender-redis-cache'));
 
 server.start();


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/131587237

This will make prerender only re-render a page once per day, which should be fine for search engine purchases. This way, even if the middleware is forwarding all requests, it would not result in all those requests coming back to the application and being rendered.